### PR TITLE
Fix EWS authentication using NTLM by using httpclient5 5.2.x which still has NTLM auth support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		
+		<httpclient5.version>5.2.3</httpclient5.version><!-- > 5.3 removed NTLM auth, which we need for Exchange/EWS -->
 
 	</properties>
 


### PR DESCRIPTION
**Description**

NTLM auth support was dropped continuing with httpclient5 5.3 versions, which we still need for EWS/Exchange authentication.

**Reference**

#109
