### PR TITLE
change default mode to fallbackGeneric, but make the default configurable

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,6 +1,9 @@
 # https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
 changelog:
   categories:
+    - title: 🛠 Breaking Changes
+      labels:
+        - breaking-change
     - title: 🎉 New Features
       labels:
         - enhancement

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ For development, a Active Directory / Exchange environment is not needed. It is 
 
 ### Using the API
 
-`GET /avatar?uid=john.doe[&m=identicon|404|fallbackIdenticon][&size=64]`
+`GET /avatar?uid=john.doe[&m=identicon|404|fallbackIdenticon|...][&size=64]`
 
 Possible modes (`m`):
 
 - `404`: 404 Response, if the user has no photo stored in AD/Exchange
-- `identicon`: **default** - renders an [Identicon](https://en.wikipedia.org/wiki/Identicon), if the user has no photo stored in AD/Exchange
+- `identicon`: renders an [Identicon](https://en.wikipedia.org/wiki/Identicon), if the user has no photo stored in AD/Exchange
 - `fallbackIdenticon`: identical to `identicon`, but also responds with an Identicon if the user itself does not exist in AD/Exchange
 - `generic`: renders an [generic placeholder icon](ad2image-spring-boot-starter/src/main/resources/account_64.png), if the user has no photo stored in AD/Exchange
-- `fallbackGeneric`: identical to `generic`, but also responds with an generic placeholder icon if the user itself does not exist in AD/Exchange
+- `fallbackGeneric`: **default** - identical to `generic`, but also responds with an generic placeholder icon if the user itself does not exist in AD/Exchange
 - `triangle`: renders an [randomly generated Avatar based on triangles](https://raw.githubusercontent.com/gabrie-allaigre/avatar-generator/master/doc/triangle1.png), if the user has no photo stored in AD/Exchange
 - `fallbackTriangle`: identical to `triangle`, but also responds correspondingly if the user itself does not exist in AD/Exchange
 - `square`: renders an [randomly generated Avatar based on squares](https://raw.githubusercontent.com/gabrie-allaigre/avatar-generator/master/doc/square1.png), if the user has no photo stored in AD/Exchange
@@ -71,7 +71,7 @@ OpenAPI v3 documentation is also provided and can be retrieved via Swagger UI (`
 You can use the provided official Docker image [ghcr.io/it-at-m/ad2image](https://github.com/it-at-m/ad2image/pkgs/container/ad2image) to run **ad2image** as a standalone application.
 
 ```sh
-docker run -d -p 8080:8080 --name ad2image ghcr.io/it-at-m/ad2image:1.0.7
+docker run -d -p 8080:8080 --name ad2image ghcr.io/it-at-m/ad2image:1.1.1
 ```
 
 To connect to your Exchange/EWS environment, some environment variables must be set, see [Configuration](#configuration) for a full list.
@@ -102,7 +102,7 @@ ad2image can be integrated in a existing Spring Boot application by adding the `
 <dependency>
   <groupId>de.muenchen.oss.ad2image</groupId>
   <artifactId>ad2image-spring-boot-starter</artifactId>
-  <version>1.0.4</version>
+  <version>1.1.1</version><!-- see GitHub Release for latest version -->
 </dependency>
 ```
 
@@ -113,12 +113,13 @@ To configure ad2image, add the corresponding `de.muenchen.oss.ad2image.*` proper
 ad2image can be configured via Spring environment abstraction.
 
 | Environment variable                             | System/Spring property                           | Description                                                                                                                                                                                                                     | Default value                                     | Required |
-| ------------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------- |
+|--------------------------------------------------|--------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|----------|
+| `DE_MUENCHEN_OSS_AD2IMAGE_DEFAULT_MODE`          | `de.muenchen.oss.ad2image.default-mode`          | Default mode (`m`) if user provides none.                                                                                                                                                                                       | `"M_FALLBACK_GENERIC"` (`fallbackGeneric`)        | yes      |
 | `DE_MUENCHEN_OSS_AD2IMAGE_AD_URL`                | `de.muenchen.oss.ad2image.ad.url`                | Connection URL for AD server, for example 'ldaps://ad.mydomain.com:636'.                                                                                                                                                        | -                                                 | yes      |
 | `DE_MUENCHEN_OSS_AD2IMAGE_AD_USER_DN`            | `de.muenchen.oss.ad2image.ad.user-dn`            | Bind User-DN for AD authentication                                                                                                                                                                                              | -                                                 | yes      |
 | `DE_MUENCHEN_OSS_AD2IMAGE_AD_PASSWORD`           | `de.muenchen.oss.ad2image.ad.password`           | Password for AD authentication                                                                                                                                                                                                  | -                                                 | yes      |
 | `DE_MUENCHEN_OSS_AD2IMAGE_AD_USER_SEARCH_BASE`   | `de.muenchen.oss.ad2image.ad.user-search-base`   | User Search Base for user lookup, for example 'OU=Users,DC=mycompany,DC=com'.                                                                                                                                                   | -                                                 | yes      |
-| `DE_MUENCHEN_OSS_AD2IMAGE_AD_USER_SEARCH_FILTER` | `de.muenchen.oss.ad2image.ad.user-search-filter` | User Search filter, `{uid}` will be replaced with the requested user uid.                                                                                                                                                       | `(&(objectClass=organizationalPerson)(cn={uid}))` |
+| `DE_MUENCHEN_OSS_AD2IMAGE_AD_USER_SEARCH_FILTER` | `de.muenchen.oss.ad2image.ad.user-search-filter` | User Search filter, `{uid}` will be replaced with the requested user uid.                                                                                                                                                       | `(&(objectClass=organizationalPerson)(cn={uid}))` | yes      |
 | `DE_MUENCHEN_OSS_AD2IMAGE_EWS_EWS_SERVICE_URL`   | `de.muenchen.oss.ad2image.ews.ews-service-url`   | [EWS service URL](https://learn.microsoft.com/en-US/exchange/client-developer/exchange-web-services/how-to-set-the-ews-service-url-by-using-the-ews-managed-api), e.g. `https://computer.domain.contoso.com/EWS/Exchange.asmx`. | -                                                 | yes      |
 | `DE_MUENCHEN_OSS_AD2IMAGE_EWS_USERNAME`          | `de.muenchen.oss.ad2image.ews.username`          | Username for EWS [NTLM authentication](https://learn.microsoft.com/en-us/exchange/client-developer/exchange-web-services/authentication-and-ews-in-exchange#ntlm-authentication).                                               | -                                                 | yes      |
 | `DE_MUENCHEN_OSS_AD2IMAGE_EWS_PASSWORD`          | `de.muenchen.oss.ad2image.ews.password`          | Password for EWS [NTLM authentication](https://learn.microsoft.com/en-us/exchange/client-developer/exchange-web-services/authentication-and-ews-in-exchange#ntlm-authentication).                                               | -                                                 | yes      |

--- a/ad2image-app/src/test/java/de/muenchen/oss/ad2image/app/AvatarApplicationTest.java
+++ b/ad2image-app/src/test/java/de/muenchen/oss/ad2image/app/AvatarApplicationTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import java.io.IOException;
 import java.nio.file.Files;
 
+import de.muenchen.oss.ad2image.starter.core.Mode;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
@@ -80,7 +81,7 @@ class AvatarApplicationTest {
 
     @Test
     void avatar_request_ok() throws IOException {
-        Mockito.when(loader.loadAvatar(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+        Mockito.when(loader.loadAvatar(Mockito.anyString(), Mockito.any(), Mockito.any()))
                 .thenReturn(Files.readAllBytes(new ClassPathResource("account_dummy.png").getFile().toPath()));
 
         CloseableHttpResponse firstResponse = httpClient.execute(new HttpGet("http://localhost:" + port + "/avatar?uid=dummy.user"));
@@ -90,7 +91,7 @@ class AvatarApplicationTest {
         Assertions.assertThat(secondResponse.getCode()).isEqualTo(200);
 
         // second request should get cached - so just 1 call to loader
-        Mockito.verify(loader, times(1)).loadAvatar("dummy.user", "identicon", ImageSize.HR64);
+        Mockito.verify(loader, times(1)).loadAvatar("dummy.user", Mode.M_FALLBACK_GENERIC, ImageSize.HR64);
     }
 
 }

--- a/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/core/Ad2ImageConfigurationProperties.java
+++ b/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/core/Ad2ImageConfigurationProperties.java
@@ -49,6 +49,11 @@ public class Ad2ImageConfigurationProperties {
      */
     private boolean enabled = true;
 
+    /**
+     * default mode
+     */
+    private Mode defaultMode = Mode.M_FALLBACK_GENERIC;
+
     public AdConfigurationProperties getAd() {
         return ad;
     }
@@ -73,4 +78,11 @@ public class Ad2ImageConfigurationProperties {
         this.enabled = enabled;
     }
 
+    public Mode getDefaultMode() {
+        return defaultMode;
+    }
+
+    public void setDefaultMode(Mode defaultMode) {
+        this.defaultMode = defaultMode;
+    }
 }

--- a/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/core/AvatarLoader.java
+++ b/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/core/AvatarLoader.java
@@ -57,18 +57,6 @@ import com.talanlabs.avatargenerator.TriangleAvatar;
 
 public class AvatarLoader {
 
-    public static final String MODE_404 = "404";
-    public static final String MODE_IDENTICON = "identicon";
-    public static final String MODE_FALLBACK_IDENTICON = "fallbackIdenticon";
-    public static final String MODE_GENERIC = "generic";
-    public static final String MODE_FALLBACK_GENERIC = "fallbackGeneric";
-    public static final String MODE_TRIANGLE = "triangle";
-    public static final String MODE_FALLBACK_TRIANGLE = "fallbackTriangle";
-    public static final String MODE_SQUARE = "square";
-    public static final String MODE_FALLBACK_SQUARE = "fallbackSquare";
-    public static final String MODE_GITHUB = "github";
-    public static final String MODE_FALLBACK_GITHUB = "fallbackGithub";
-
     private static final Logger log = LoggerFactory.getLogger(AvatarLoader.class);
 
     private final LdapTemplate ldapTemplate;
@@ -114,7 +102,7 @@ public class AvatarLoader {
         return avatarBuilders;
     }
 
-    public byte[] loadAvatar(String uid, String mode, ImageSize size) {
+    public byte[] loadAvatar(String uid, Mode mode, ImageSize size) {
         log.info("Looking up '{}' in AD (mode='{}', size='{}')...", uid, mode, size);
         List<User> users = findPersonInAD(uid);
         if (users.size() == 1) {
@@ -156,21 +144,21 @@ public class AvatarLoader {
         }
     }
 
-    private byte[] generateFallbackAvatar(String uid, String mode, ImageSize size) {
+    private byte[] generateFallbackAvatar(String uid, Mode mode, ImageSize size) {
         switch (mode) {
-        case MODE_IDENTICON, MODE_FALLBACK_IDENTICON:
+        case M_IDENTICON, M_FALLBACK_IDENTICON:
             log.debug("Generating identicon fallback avatar for '{}'.", uid);
             return identiconAvatarBuilders.get(size).createAsPngBytes(uid.hashCode());
-        case MODE_GENERIC, MODE_FALLBACK_GENERIC:
+        case M_GENERIC, M_FALLBACK_GENERIC:
             log.debug("Using generic fallback avatar for '{}'.", uid);
             return getGenericPhoto(size);
-        case MODE_TRIANGLE, MODE_FALLBACK_TRIANGLE:
+        case M_TRIANGLE, M_FALLBACK_TRIANGLE:
             log.debug("Generating triangle fallback avatar for '{}'.", uid);
             return triangleAvatarBuilders.get(size).createAsPngBytes(uid.hashCode());
-        case MODE_SQUARE, MODE_FALLBACK_SQUARE:
+        case M_SQUARE, M_FALLBACK_SQUARE:
             log.debug("Generating square fallback avatar for '{}'.", uid);
             return squareAvatarBuilders.get(size).createAsPngBytes(uid.hashCode());
-        case MODE_GITHUB, MODE_FALLBACK_GITHUB:
+        case M_GITHUB, M_FALLBACK_GITHUB:
             log.debug("Generating github fallback avatar for '{}'.", uid);
             return githubAvatarBuilders.get(size).createAsPngBytes(uid.hashCode());
         default:

--- a/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/core/Mode.java
+++ b/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/core/Mode.java
@@ -1,6 +1,6 @@
 /*
  * The MIT License
- * Copyright © 2022 Landeshauptstadt München | it@M
+ * Copyright © 2025 Landeshauptstadt München | it@M
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,25 +20,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package de.muenchen.oss.ad2image.starter.spring;
+package de.muenchen.oss.ad2image.starter.core;
 
-import de.muenchen.oss.ad2image.starter.core.Mode;
-import org.springframework.cache.annotation.Cacheable;
+public enum Mode {
+    M_404("404"),
+    M_IDENTICON("identicon"),
+    M_FALLBACK_IDENTICON("fallbackIdenticon"),
+    M_GITHUB("github"),
+    M_FALLBACK_GITHUB("fallbackGithub"),
+    M_GENERIC("generic"),
+    M_FALLBACK_GENERIC("fallbackGeneric"),
+    M_TRIANGLE("triangle"),
+    M_FALLBACK_TRIANGLE("fallbackTriangle"),
+    M_SQUARE("square"),
+    M_FALLBACK_SQUARE("fallbackSquare");
 
-import de.muenchen.oss.ad2image.starter.core.AvatarLoader;
-import de.muenchen.oss.ad2image.starter.core.ImageSize;
+    private final String parameterValue;
 
-public class AvatarService {
-
-    private final AvatarLoader avatarLoader;
-
-    public AvatarService(AvatarLoader avatarLoader) {
-        this.avatarLoader = avatarLoader;
+    Mode(String parameterValue) {
+        this.parameterValue = parameterValue;
     }
 
-    @Cacheable("avatars")
-    public byte[] get(String uid, Mode mode, ImageSize size) {
-        return avatarLoader.loadAvatar(uid, mode, size);
+    public String getParameterValue() {
+        return parameterValue;
     }
-
 }

--- a/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/spring/Ad2ImageAutoConfiguration.java
+++ b/ad2image-spring-boot-starter/src/main/java/de/muenchen/oss/ad2image/starter/spring/Ad2ImageAutoConfiguration.java
@@ -65,8 +65,8 @@ public class Ad2ImageAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    AvatarController avatarController(AvatarService service) {
-        return new AvatarController(service);
+    AvatarController avatarController(AvatarService service, Ad2ImageConfigurationProperties ad2ImageProps) {
+        return new AvatarController(service, ad2ImageProps);
     }
 
     @Bean("ad2ImageLdapTemplate")

--- a/ad2image-spring-boot-starter/src/test/java/de/muenchen/oss/ad2image/core/AvatarLoaderTest.java
+++ b/ad2image-spring-boot-starter/src/test/java/de/muenchen/oss/ad2image/core/AvatarLoaderTest.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
+import de.muenchen.oss.ad2image.starter.core.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,11 +53,6 @@ import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldif.LDIFException;
 import com.unboundid.ldif.LDIFReader;
 
-import de.muenchen.oss.ad2image.starter.core.AdConfigurationProperties;
-import de.muenchen.oss.ad2image.starter.core.AvatarLoader;
-import de.muenchen.oss.ad2image.starter.core.ExchangeConfigurationProperties;
-import de.muenchen.oss.ad2image.starter.core.ImageSize;
-
 /**
  * @author michael.prankl
  *
@@ -74,7 +70,7 @@ class AvatarLoaderTest {
     @Test
     void default_size_from_ad() throws IOException {
         String uid = "maxi.mustermann";
-        byte[] loadAvatar = sut.loadAvatar(uid, "identicon", ImageSize.getAdDefaultImageSize());
+        byte[] loadAvatar = sut.loadAvatar(uid, Mode.M_IDENTICON, ImageSize.getAdDefaultImageSize());
         assertThat(loadAvatar).isNotEmpty();
         Files.write(new File("target/" + uid + "_64.jpg").toPath(), loadAvatar);
     }
@@ -100,7 +96,7 @@ class AvatarLoaderTest {
                         ok().withBodyFile("account_dummy.png")));
         // @formatter:on
         String uid = "maxi.mustermann";
-        byte[] loadAvatar = sut.loadAvatar(uid, "identicon", ImageSize.HR648);
+        byte[] loadAvatar = sut.loadAvatar(uid, Mode.M_IDENTICON, ImageSize.HR648);
         assertThat(loadAvatar).isNotEmpty();
         Files.write(new File("target/" + uid + "_648.jpg").toPath(), loadAvatar);
     }
@@ -108,7 +104,7 @@ class AvatarLoaderTest {
     @Test
     void no_user_fallbackIdenticon() throws IOException {
         String uid = "dengibtsned.imad";
-        byte[] loadAvatar = sut.loadAvatar(uid, "fallbackIdenticon", ImageSize.HR648);
+        byte[] loadAvatar = sut.loadAvatar(uid, Mode.M_FALLBACK_GENERIC, ImageSize.HR648);
         assertThat(loadAvatar).isNotEmpty();
         Files.write(new File("target/" + uid + "_648.png").toPath(), loadAvatar);
     }
@@ -116,7 +112,7 @@ class AvatarLoaderTest {
     @Test
     void user_without_picture_fallback() throws IOException {
         String uid = "nophoto.user";
-        byte[] loadAvatar = sut.loadAvatar(uid, "fallbackIdenticon", ImageSize.HR648);
+        byte[] loadAvatar = sut.loadAvatar(uid, Mode.M_FALLBACK_GENERIC, ImageSize.HR648);
         assertThat(loadAvatar).isNotEmpty();
         Files.write(new File("target/" + uid + "_648.png").toPath(), loadAvatar);
     }
@@ -124,7 +120,7 @@ class AvatarLoaderTest {
     @Test
     void user_without_picture_no_fallback() throws IOException {
         String uid = "nophoto.user";
-        byte[] loadAvatar = sut.loadAvatar(uid, "404", ImageSize.HR648);
+        byte[] loadAvatar = sut.loadAvatar(uid, Mode.M_404, ImageSize.HR648);
         assertThat(loadAvatar).isNull();
     }
 


### PR DESCRIPTION
**Description**

Changes the "default" mode to `fallbackGeneric` from `identicon`.

If users want to stick with the current behaviour or want another "default" mode, they now have the possibility to overwrite the default, e.g. by setting system-property `de.muenchen.oss.ad2image.default-mode` to `M_IDENTICON`

**Reference**

Issues #116 
